### PR TITLE
Exception

### DIFF
--- a/varnish/varnishstat.py
+++ b/varnish/varnishstat.py
@@ -51,9 +51,12 @@ class Varnishstat (object):
 
         doc = json.loads(output)
         for stat in doc:
-            name = stat
-            value = doc[stat]["value"]
-            yield(name, int(value))
+            try:
+                name = stat
+                value = doc[stat]["value"]
+                yield(name, int(value))
+            except:
+                continue
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
JSON output contain some entries not needed for ganglia plugin. This fix should silently skip such entries and avoid exception:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 551, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/dist-packages/varnish/stats.py", line 86, in run
    self.update_metrics()
  File "/usr/lib/python2.7/dist-packages/varnish/stats.py", line 65, in update_metrics
    for name, value in self.varnishstat.read_metrics():
  File "/usr/lib/python2.7/dist-packages/varnish/varnishstat.py", line 55, in read_metrics
    value = doc[stat]["value"]
TypeError: string indices must be integers
```
