### PR TITLE
changes for varnish 4.1

### DIFF
--- a/lib/varnish_plugin.py
+++ b/lib/varnish_plugin.py
@@ -3,6 +3,8 @@
 import os
 import sys
 import optparse
+
+sys.path.remove('/usr/lib/ganglia/python_modules')
 import varnish.stats
 
 CONFIG_TEMPLATE = '''

--- a/varnish/varnishstat.py
+++ b/varnish/varnishstat.py
@@ -29,13 +29,14 @@ class Varnishstat (object):
             stdout=subprocess.PIPE)
 
         for line in iter(p.stdout.readline, b''):
-            name, val, avg, desc = line.strip().split(None, 3)
-            if name in forced_metrics:
-                m.append((name, desc, forced_metrics[name]))
-            elif avg == '.':
-                m.append((name, desc, m_count))
-            else:
-                m.append((name, desc, m_rate))
+            if line.strip() != '':
+              name, val, avg, desc = line.strip().split(None, 3)
+              if name in forced_metrics:
+                  m.append((name, desc, forced_metrics[name]))
+              elif avg == '.':
+                  m.append((name, desc, m_count))
+              else:
+                  m.append((name, desc, m_rate))
 
         p.communicate()
 


### PR DESCRIPTION
- removing /usr/lib/ganglia/python_modules because varnish_plugin.py interpret already locally installed varnish.py _module_ (being part of ganglia-monitor-python package) as its counterpart (which is wrong because proper varnish[.stats] module is installed in /usr/lib/python2.7/dist-packages). Local path is the first one in sys.path for python so I'm removing it from search.
- varnish 4.1 leaves trailing line at the end of varnishstat which breaks split operation 
